### PR TITLE
Cloud init fixes + retentionPolicy deprecation

### DIFF
--- a/artefacts/cloud-init-linux-jumpbox.yaml
+++ b/artefacts/cloud-init-linux-jumpbox.yaml
@@ -1,6 +1,9 @@
 #cloud-config
 package_update: true
 package_upgrade: true
+apt:
+  conf: |
+    DPkg::Lock::Timeout "-1";
 packages:
   - nfs-common
   - jq

--- a/config/diagnostics.json
+++ b/config/diagnostics.json
@@ -2,21 +2,13 @@
     "logs": [
         {
             "categoryGroup": "allLogs",
-            "enabled": true,
-            "retentionPolicy": {
-                "days": 11,
-                "enabled": true
-            }
+            "enabled": true
         }
     ],
     "metrics": [
         {
             "category": "AllMetrics",
-            "enabled": true,
-            "retentionPolicy": {
-                "days": 1,
-                "enabled": true
-            }
+            "enabled": true
         }
     ]
 }

--- a/connectivity.bicep
+++ b/connectivity.bicep
@@ -144,10 +144,6 @@ var enabledLogsCategories = map(enabledLogs, item => item.categoryGroup)
 var enabledMetrics = filter(diagnosticConfig.metrics, item => item.enabled)
 var enabledMetricsCategories = map(enabledMetrics, item => item.category)
 
-// Retention Days are only read from the logs settings
-var retentionDaysRaw = map(enabledLogs, item => item.retentionPolicy.enabled ? item.retentionPolicy.days : 0)
-var retentionDays = max(union(retentionDaysRaw,[10]))
-
 
 //------------------------------------------------------------------------------
 // Resources
@@ -177,7 +173,6 @@ module logAnalyticsWorkspace './modules/Microsoft.OperationalInsights/workspaces
     serviceTier: logAnalyticsServiceTier
     diagnosticMetricsToEnable: enabledMetricsCategories
     diagnosticLogCategoriesToEnable: enabledLogsCategories
-    diagnosticLogsRetentionInDays: retentionDays
     enableDefaultTelemetry: false 
   }
   dependsOn: [
@@ -223,7 +218,6 @@ module hubNSGbastion './modules/Microsoft.Network/networkSecurityGroups/deploy.b
     tags: allTags
     securityRules: contains(hubConfig, 'networkSecurityGroups') ? hubConfig.networkSecurityGroups.bastion : {}
     enableDefaultTelemetry: false
-    diagnosticLogsRetentionInDays: retentionDays
     diagnosticLogCategoriesToEnable: enabledLogsCategories
     diagnosticWorkspaceId: logAnalyticsWorkspace.outputs.resourceId
   }
@@ -244,7 +238,6 @@ module hubNSGjumpbox './modules/Microsoft.Network/networkSecurityGroups/deploy.b
     tags: allTags
     securityRules: contains(hubConfig, 'networkSecurityGroups') ? hubConfig.networkSecurityGroups.jumpbox : {}
     enableDefaultTelemetry: false
-    diagnosticLogsRetentionInDays: retentionDays
     diagnosticLogCategoriesToEnable: enabledLogsCategories
     diagnosticWorkspaceId: logAnalyticsWorkspace.outputs.resourceId
   }
@@ -299,7 +292,6 @@ module hubVnet './modules/Microsoft.Network/virtualNetworks/deploy.bicep' = {
     location: location
     tags: allTags
     enableDefaultTelemetry: false
-    diagnosticLogsRetentionInDays: retentionDays
     diagnosticLogCategoriesToEnable: enabledLogsCategories
     diagnosticMetricsToEnable: enabledMetricsCategories
     diagnosticWorkspaceId: logAnalyticsWorkspace.outputs.resourceId
@@ -338,7 +330,6 @@ module azFirewall './modules/Microsoft.Network/azureFirewalls/deploy.bicep' = if
     networkRuleCollections: azFwConfig.networkRuleCollections.value
     zones:  hubConfig.publicIPSettings.zones
     enableDefaultTelemetry: false
-    diagnosticLogsRetentionInDays: retentionDays
     diagnosticLogCategoriesToEnable: enabledLogsCategories
     diagnosticMetricsToEnable: enabledMetricsCategories
     diagnosticWorkspaceId: logAnalyticsWorkspace.outputs.resourceId
@@ -370,7 +361,6 @@ module azBastion './modules/Microsoft.Network/bastionHosts/deploy.bicep' = if (d
     vNetId: hubVnet.outputs.resourceId
     publicIPAddressObject: pipAzBastionAddressObject
     enableDefaultTelemetry: false
-    diagnosticLogsRetentionInDays: retentionDays
     diagnosticLogCategoriesToEnable: enabledLogsCategories
     diagnosticWorkspaceId: logAnalyticsWorkspace.outputs.resourceId
   }
@@ -400,7 +390,6 @@ module vpnGateway './modules/Microsoft.Network/virtualNetworkGateways/deploy.bic
     activeActive:  vpngConfig.activeActive
     gatewayPipName: 'pip-${rsPrefix}-vpngw'
     enableDefaultTelemetry: false
-    diagnosticLogsRetentionInDays: retentionDays
     diagnosticMetricsToEnable: enabledMetricsCategories
     diagnosticWorkspaceId: logAnalyticsWorkspace.outputs.resourceId
     vpnClientAddressPoolPrefix: vpngConfig.vpnClientAddressPoolPrefix
@@ -570,7 +559,6 @@ module linuxJumpBox './modules/Microsoft.Compute/virtualMachines/deploy.bicep' =
     adminUsername: vmJumpBoxConfig.linux.adminUsername
     adminPassword: adminPassword
     enableDefaultTelemetry: false
-    diagnosticLogsRetentionInDays: retentionDays
     diagnosticWorkspaceId: logAnalyticsWorkspace.outputs.resourceId
     userAssignedIdentities: jumpBoxUserAssignedIdentitiesObject 
     }
@@ -613,7 +601,6 @@ module windowsJumpBox './modules/Microsoft.Compute/virtualMachines/deploy.bicep'
     adminUsername: vmJumpBoxConfig.windows.adminUsername
     adminPassword: adminPassword
     enableDefaultTelemetry: false
-    diagnosticLogsRetentionInDays: retentionDays
     diagnosticWorkspaceId: logAnalyticsWorkspace.outputs.resourceId
     securityType: contains(vmJumpBoxConfig.windows,'securityType') ? vmJumpBoxConfig.windows.securityType : ''
     vTpmEnabled: contains(vmJumpBoxConfig.windows, 'vTpmEnabled') ? vmJumpBoxConfig.windows.vTpmEnabled : false

--- a/modules/Microsoft.Compute/virtualMachines/.bicep/nested_networkInterface.bicep
+++ b/modules/Microsoft.Compute/virtualMachines/.bicep/nested_networkInterface.bicep
@@ -12,7 +12,6 @@ param networkSecurityGroupResourceId string = ''
 param ipConfigurations array
 param lock string = ''
 param diagnosticStorageAccountId string
-param diagnosticLogsRetentionInDays int
 param diagnosticWorkspaceId string
 param diagnosticEventHubAuthorizationRuleId string
 param diagnosticEventHubName string
@@ -38,7 +37,6 @@ module networkInterface_publicIPAddresses '../../../Microsoft.Network/publicIPAd
     diagnosticEventHubAuthorizationRuleId: diagnosticEventHubAuthorizationRuleId
     diagnosticEventHubName: diagnosticEventHubName
     diagnosticLogCategoriesToEnable: pipdiagnosticLogCategoriesToEnable
-    diagnosticLogsRetentionInDays: diagnosticLogsRetentionInDays
     diagnosticMetricsToEnable: pipdiagnosticMetricsToEnable
     diagnosticSettingsName: pipDiagnosticSettingsName
     diagnosticStorageAccountId: diagnosticStorageAccountId
@@ -80,7 +78,6 @@ module networkInterface '../../../Microsoft.Network/networkInterfaces/deploy.bic
     tags: tags
     diagnosticEventHubAuthorizationRuleId: diagnosticEventHubAuthorizationRuleId
     diagnosticEventHubName: diagnosticEventHubName
-    diagnosticLogsRetentionInDays: diagnosticLogsRetentionInDays
     diagnosticStorageAccountId: diagnosticStorageAccountId
     diagnosticMetricsToEnable: nicDiagnosticMetricsToEnable
     diagnosticSettingsName: nicDiagnosticSettingsName

--- a/modules/Microsoft.Compute/virtualMachines/.test/linux/deploy.test.bicep
+++ b/modules/Microsoft.Compute/virtualMachines/.test/linux/deploy.test.bicep
@@ -162,7 +162,6 @@ module testDeployment '../../deploy.bicep' = {
     diagnosticWorkspaceId: diagnosticDependencies.outputs.logAnalyticsWorkspaceResourceId
     diagnosticEventHubAuthorizationRuleId: diagnosticDependencies.outputs.eventHubAuthorizationRuleId
     diagnosticEventHubName: diagnosticDependencies.outputs.eventHubNamespaceEventHubName
-    diagnosticLogsRetentionInDays: 7
     disablePasswordAuthentication: true
     encryptionAtHost: false
     extensionCustomScriptConfig: {

--- a/modules/Microsoft.Compute/virtualMachines/.test/windows/deploy.test.bicep
+++ b/modules/Microsoft.Compute/virtualMachines/.test/windows/deploy.test.bicep
@@ -166,7 +166,6 @@ module testDeployment '../../deploy.bicep' = {
     diagnosticWorkspaceId: diagnosticDependencies.outputs.logAnalyticsWorkspaceResourceId
     diagnosticEventHubAuthorizationRuleId: diagnosticDependencies.outputs.eventHubAuthorizationRuleId
     diagnosticEventHubName: diagnosticDependencies.outputs.eventHubNamespaceEventHubName
-    diagnosticLogsRetentionInDays: 7
     encryptionAtHost: false
     extensionAntiMalwareConfig: {
       enabled: true

--- a/modules/Microsoft.Compute/virtualMachines/deploy.bicep
+++ b/modules/Microsoft.Compute/virtualMachines/deploy.bicep
@@ -223,11 +223,6 @@ param extensionCustomScriptProtectedSetting object = {}
 @description('Optional. Location for all resources.')
 param location string = resourceGroup().location
 
-@description('Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely.')
-@minValue(0)
-@maxValue(365)
-param diagnosticLogsRetentionInDays int = 365
-
 @description('Optional. Resource ID of the diagnostic storage account.')
 param diagnosticStorageAccountId string = ''
 
@@ -401,7 +396,6 @@ module vm_nic '.bicep/nested_networkInterface.bicep' = [for (nicConfiguration, i
     ipConfigurations: nicConfiguration.ipConfigurations
     lock: lock
     diagnosticStorageAccountId: diagnosticStorageAccountId
-    diagnosticLogsRetentionInDays: diagnosticLogsRetentionInDays
     diagnosticWorkspaceId: diagnosticWorkspaceId
     diagnosticEventHubAuthorizationRuleId: diagnosticEventHubAuthorizationRuleId
     diagnosticEventHubName: diagnosticEventHubName

--- a/modules/Microsoft.Insights/diagnosticSettings/deploy.bicep
+++ b/modules/Microsoft.Insights/diagnosticSettings/deploy.bicep
@@ -5,11 +5,6 @@ targetScope = 'subscription'
 @maxLength(260)
 param name string = '${uniqueString(subscription().id)}-ActivityLog'
 
-@description('Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely.')
-@minValue(0)
-@maxValue(365)
-param diagnosticLogsRetentionInDays int = 365
-
 @description('Optional. Resource ID of the diagnostic storage account.')
 param diagnosticStorageAccountId string = ''
 
@@ -47,20 +42,12 @@ param location string = deployment().location
 var diagnosticsLogsSpecified = [for category in filter(diagnosticLogCategoriesToEnable, item => item != 'allLogs'): {
   category: category
   enabled: true
-  retentionPolicy: {
-    enabled: true
-    days: diagnosticLogsRetentionInDays
-  }
 }]
 
 var diagnosticsLogs = contains(diagnosticLogCategoriesToEnable, 'allLogs') ? [
   {
     categoryGroup: 'allLogs'
     enabled: true
-    retentionPolicy: {
-      enabled: true
-      days: diagnosticLogsRetentionInDays
-    }
   }
 ] : diagnosticsLogsSpecified
 

--- a/modules/Microsoft.Network/azureFirewalls/deploy.bicep
+++ b/modules/Microsoft.Network/azureFirewalls/deploy.bicep
@@ -62,11 +62,6 @@ param diagnosticStorageAccountId string = ''
 @description('Optional. Log Analytics workspace resource identifier.')
 param diagnosticWorkspaceId string = ''
 
-@description('Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely.')
-@minValue(0)
-@maxValue(365)
-param diagnosticLogsRetentionInDays int = 365
-
 @description('Optional. Resource ID of the diagnostic event hub authorization rule for the Event Hubs namespace in which the event hub should be created or streamed to.')
 param diagnosticEventHubAuthorizationRuleId string = ''
 
@@ -161,20 +156,12 @@ var ipConfigurations = concat([
 var diagnosticsLogsSpecified = [for category in filter(diagnosticLogCategoriesToEnable, item => item != 'allLogs'): {
   category: category
   enabled: true
-  retentionPolicy: {
-    enabled: true
-    days: diagnosticLogsRetentionInDays
-  }
 }]
 
 var diagnosticsLogs = contains(diagnosticLogCategoriesToEnable, 'allLogs') ? [
   {
     categoryGroup: 'allLogs'
     enabled: true
-    retentionPolicy: {
-      enabled: true
-      days: diagnosticLogsRetentionInDays
-    }
   }
 ] : diagnosticsLogsSpecified
 
@@ -182,10 +169,6 @@ var diagnosticsMetrics = [for metric in diagnosticMetricsToEnable: {
   category: metric
   timeGrain: null
   enabled: true
-  retentionPolicy: {
-    enabled: true
-    days: diagnosticLogsRetentionInDays
-  }
 }]
 
 resource defaultTelemetry 'Microsoft.Resources/deployments@2021-04-01' = if (enableDefaultTelemetry) {
@@ -226,7 +209,6 @@ module publicIPAddress '../../Microsoft.Network/publicIPAddresses/deploy.bicep' 
     ]
     location: location
     diagnosticStorageAccountId: diagnosticStorageAccountId
-    diagnosticLogsRetentionInDays: diagnosticLogsRetentionInDays
     diagnosticWorkspaceId: diagnosticWorkspaceId
     diagnosticEventHubAuthorizationRuleId: diagnosticEventHubAuthorizationRuleId
     diagnosticEventHubName: diagnosticEventHubName

--- a/modules/Microsoft.Network/bastionHosts/deploy.bicep
+++ b/modules/Microsoft.Network/bastionHosts/deploy.bicep
@@ -16,11 +16,6 @@ param isCreateDefaultPublicIP bool = true
 @description('Optional. Specifies the properties of the public IP to create and be used by Azure Bastion. If it\'s not provided and publicIPAddressResourceId is empty, a \'-pip\' suffix will be appended to the Bastion\'s name.')
 param publicIPAddressObject object = {}
 
-@description('Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely.')
-@minValue(0)
-@maxValue(365)
-param diagnosticLogsRetentionInDays int = 365
-
 @description('Optional. Resource ID of the diagnostic storage account.')
 param diagnosticStorageAccountId string = ''
 
@@ -87,20 +82,12 @@ param diagnosticSettingsName string = '${name}-diagnosticSettings'
 var diagnosticsLogsSpecified = [for category in filter(diagnosticLogCategoriesToEnable, item => item != 'allLogs'): {
   category: category
   enabled: true
-  retentionPolicy: {
-    enabled: true
-    days: diagnosticLogsRetentionInDays
-  }
 }]
 
 var diagnosticsLogs = contains(diagnosticLogCategoriesToEnable, 'allLogs') ? [
   {
     categoryGroup: 'allLogs'
     enabled: true
-    retentionPolicy: {
-      enabled: true
-      days: diagnosticLogsRetentionInDays
-    }
   }
 ] : diagnosticsLogsSpecified
 
@@ -166,7 +153,6 @@ module publicIPAddress '../publicIPAddresses/deploy.bicep' = if (empty(azureBast
       'AllMetrics'
     ]
     diagnosticStorageAccountId: diagnosticStorageAccountId
-    diagnosticLogsRetentionInDays: diagnosticLogsRetentionInDays
     diagnosticWorkspaceId: diagnosticWorkspaceId
     diagnosticEventHubAuthorizationRuleId: diagnosticEventHubAuthorizationRuleId
     diagnosticEventHubName: diagnosticEventHubName

--- a/modules/Microsoft.Network/networkInterfaces/deploy.bicep
+++ b/modules/Microsoft.Network/networkInterfaces/deploy.bicep
@@ -47,11 +47,6 @@ param lock string = ''
 @description('Optional. Array of role assignment objects that contain the \'roleDefinitionIdOrName\' and \'principalId\' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: \'/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11\'.')
 param roleAssignments array = []
 
-@description('Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely.')
-@minValue(0)
-@maxValue(365)
-param diagnosticLogsRetentionInDays int = 365
-
 @description('Optional. Resource ID of the diagnostic storage account.')
 param diagnosticStorageAccountId string = ''
 
@@ -79,10 +74,6 @@ var diagnosticsMetrics = [for metric in diagnosticMetricsToEnable: {
   category: metric
   timeGrain: null
   enabled: true
-  retentionPolicy: {
-    enabled: true
-    days: diagnosticLogsRetentionInDays
-  }
 }]
 
 resource defaultTelemetry 'Microsoft.Resources/deployments@2021-04-01' = if (enableDefaultTelemetry) {

--- a/modules/Microsoft.Network/networkSecurityGroups/deploy.bicep
+++ b/modules/Microsoft.Network/networkSecurityGroups/deploy.bicep
@@ -13,11 +13,6 @@ param flushConnection bool = false
 @description('Optional. Resource ID of the diagnostic storage account.')
 param diagnosticStorageAccountId string = ''
 
-@description('Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely.')
-@minValue(0)
-@maxValue(365)
-param diagnosticLogsRetentionInDays int = 365
-
 @description('Optional. Resource ID of the diagnostic log analytics workspace.')
 param diagnosticWorkspaceId string = ''
 
@@ -62,20 +57,12 @@ var enableReferencedModulesTelemetry = false
 var diagnosticsLogsSpecified = [for category in filter(diagnosticLogCategoriesToEnable, item => item != 'allLogs'): {
   category: category
   enabled: true
-  retentionPolicy: {
-    enabled: true
-    days: diagnosticLogsRetentionInDays
-  }
 }]
 
 var diagnosticsLogs = contains(diagnosticLogCategoriesToEnable, 'allLogs') ? [
   {
     categoryGroup: 'allLogs'
     enabled: true
-    retentionPolicy: {
-      enabled: true
-      days: diagnosticLogsRetentionInDays
-    }
   }
 ] : diagnosticsLogsSpecified
 

--- a/modules/Microsoft.Network/publicIPAddresses/deploy.bicep
+++ b/modules/Microsoft.Network/publicIPAddresses/deploy.bicep
@@ -35,11 +35,6 @@ param zones array = []
 ])
 param publicIPAddressVersion string = 'IPv4'
 
-@description('Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely.')
-@minValue(0)
-@maxValue(365)
-param diagnosticLogsRetentionInDays int = 365
-
 @description('Optional. Resource ID of the diagnostic storage account.')
 param diagnosticStorageAccountId string = ''
 
@@ -106,20 +101,12 @@ param diagnosticSettingsName string = '${name}-diagnosticSettings'
 var diagnosticsLogsSpecified = [for category in filter(diagnosticLogCategoriesToEnable, item => item != 'allLogs'): {
   category: category
   enabled: true
-  retentionPolicy: {
-    enabled: true
-    days: diagnosticLogsRetentionInDays
-  }
 }]
 
 var diagnosticsLogs = contains(diagnosticLogCategoriesToEnable, 'allLogs') ? [
   {
     categoryGroup: 'allLogs'
     enabled: true
-    retentionPolicy: {
-      enabled: true
-      days: diagnosticLogsRetentionInDays
-    }
   }
 ] : diagnosticsLogsSpecified
 
@@ -127,10 +114,6 @@ var diagnosticsMetrics = [for metric in diagnosticMetricsToEnable: {
   category: metric
   timeGrain: null
   enabled: true
-  retentionPolicy: {
-    enabled: true
-    days: diagnosticLogsRetentionInDays
-  }
 }]
 
 resource defaultTelemetry 'Microsoft.Resources/deployments@2021-04-01' = if (enableDefaultTelemetry) {

--- a/modules/Microsoft.Network/virtualNetworkGateways/deploy.bicep
+++ b/modules/Microsoft.Network/virtualNetworkGateways/deploy.bicep
@@ -96,11 +96,6 @@ param clientRootCertData string = ''
 @description('Optional. Thumbprint of the revoked certificate. This would revoke VPN client certificates matching this thumbprint from connecting to the VNet.')
 param clientRevokedCertThumbprint string = ''
 
-@description('Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely.')
-@minValue(0)
-@maxValue(365)
-param diagnosticLogsRetentionInDays int = 365
-
 @description('Optional. Resource ID of the diagnostic storage account.')
 param diagnosticStorageAccountId string = ''
 
@@ -179,20 +174,12 @@ param publicIpDiagnosticSettingsName string = 'diagnosticSettings'
 var virtualNetworkGatewayDiagnosticsLogsSpecified = [for category in filter(virtualNetworkGatewaydiagnosticLogCategoriesToEnable, item => item != 'allLogs'): {
   category: category
   enabled: true
-  retentionPolicy: {
-    enabled: true
-    days: diagnosticLogsRetentionInDays
-  }
 }]
 
 var virtualNetworkGatewayDiagnosticsLogs = contains(virtualNetworkGatewaydiagnosticLogCategoriesToEnable, 'allLogs') ? [
   {
     categoryGroup: 'allLogs'
     enabled: true
-    retentionPolicy: {
-      enabled: true
-      days: diagnosticLogsRetentionInDays
-    }
   }
 ] : virtualNetworkGatewayDiagnosticsLogsSpecified
 
@@ -200,10 +187,6 @@ var diagnosticsMetrics = [for metric in diagnosticMetricsToEnable: {
   category: metric
   timeGrain: null
   enabled: true
-  retentionPolicy: {
-    enabled: true
-    days: diagnosticLogsRetentionInDays
-  }
 }]
 
 // Other Variables

--- a/modules/Microsoft.Network/virtualNetworks/deploy.bicep
+++ b/modules/Microsoft.Network/virtualNetworks/deploy.bicep
@@ -33,11 +33,6 @@ param vnetEncryptionEnforcement string = 'AllowUnencrypted'
 @description('Optional. The flow timeout in minutes for the Virtual Network, which is used to enable connection tracking for intra-VM flows. Possible values are between 4 and 30 minutes. Default value 0 will set the property to null.')
 param flowTimeoutInMinutes int = 0
 
-@description('Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely.')
-@minValue(0)
-@maxValue(365)
-param diagnosticLogsRetentionInDays int = 365
-
 @description('Optional. Resource ID of the diagnostic storage account.')
 param diagnosticStorageAccountId string = ''
 
@@ -91,20 +86,12 @@ param diagnosticSettingsName string = '${name}-diagnosticSettings'
 var diagnosticsLogsSpecified = [for category in filter(diagnosticLogCategoriesToEnable, item => item != 'allLogs'): {
   category: category
   enabled: true
-  retentionPolicy: {
-    enabled: true
-    days: diagnosticLogsRetentionInDays
-  }
 }]
 
 var diagnosticsLogs = contains(diagnosticLogCategoriesToEnable, 'allLogs') ? [
   {
     categoryGroup: 'allLogs'
     enabled: true
-    retentionPolicy: {
-      enabled: true
-      days: diagnosticLogsRetentionInDays
-    }
   }
 ] : diagnosticsLogsSpecified
 
@@ -112,10 +99,6 @@ var diagnosticsMetrics = [for metric in diagnosticMetricsToEnable: {
   category: metric
   timeGrain: null
   enabled: true
-  retentionPolicy: {
-    enabled: true
-    days: diagnosticLogsRetentionInDays
-  }
 }]
 
 var dnsServersVar = {

--- a/modules/Microsoft.OperationalInsights/workspaces/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.OperationalInsights/workspaces/.test/common/deploy.test.bicep
@@ -152,7 +152,6 @@ module testDeployment '../../deploy.bicep' = {
         state: 'Enabled'
       }
     ]
-    diagnosticLogsRetentionInDays: 7
     diagnosticStorageAccountId: diagnosticDependencies.outputs.storageAccountResourceId
     diagnosticWorkspaceId: diagnosticDependencies.outputs.logAnalyticsWorkspaceResourceId
     diagnosticEventHubAuthorizationRuleId: diagnosticDependencies.outputs.eventHubAuthorizationRuleId

--- a/modules/Microsoft.OperationalInsights/workspaces/deploy.bicep
+++ b/modules/Microsoft.OperationalInsights/workspaces/deploy.bicep
@@ -57,11 +57,6 @@ param publicNetworkAccessForQuery string = 'Enabled'
 @description('Optional. Set to \'true\' to use resource or workspace permissions and \'false\' (or leave empty) to require workspace permissions.')
 param useResourcePermissions bool = false
 
-@description('Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely.')
-@minValue(0)
-@maxValue(365)
-param diagnosticLogsRetentionInDays int = 365
-
 @description('Optional. Resource ID of the diagnostic storage account.')
 param diagnosticStorageAccountId string = ''
 
@@ -117,20 +112,12 @@ param diagnosticSettingsName string = '${name}-diagnosticSettings'
 var diagnosticsLogsSpecified = [for category in filter(diagnosticLogCategoriesToEnable, item => item != 'allLogs'): {
   category: category
   enabled: true
-  retentionPolicy: {
-    enabled: true
-    days: diagnosticLogsRetentionInDays
-  }
 }]
 
 var diagnosticsLogs = contains(diagnosticLogCategoriesToEnable, 'allLogs') ? [
   {
     categoryGroup: 'allLogs'
     enabled: true
-    retentionPolicy: {
-      enabled: true
-      days: diagnosticLogsRetentionInDays
-    }
   }
 ] : diagnosticsLogsSpecified
 
@@ -138,10 +125,6 @@ var diagnosticsMetrics = [for metric in diagnosticMetricsToEnable: {
   category: metric
   timeGrain: null
   enabled: true
-  retentionPolicy: {
-    enabled: true
-    days: diagnosticLogsRetentionInDays
-  }
 }]
 
 var logAnalyticsSearchVersion = 1

--- a/optional/deploySpoke.bicep
+++ b/optional/deploySpoke.bicep
@@ -102,11 +102,6 @@ var enabledLogsCategories = map(enabledLogs, item => item.categoryGroup)
 var enabledMetrics = filter(diagnosticConfig.metrics, item => item.enabled)
 var enabledMetricsCategories = map(enabledMetrics, item => item.category)
 
-// Retention Days are only read from the logs settings
-var retentionDaysRaw = map(enabledLogs, item => item.retentionPolicy.enabled ? item.retentionPolicy.days : 0)
-var retentionDays = max(union(retentionDaysRaw,[10]))
-
-
 //------------------------------------------------------------------------------
 // Resources
 //------------------------------------------------------------------------------
@@ -130,7 +125,6 @@ module spokeDefaultNSG '../modules/Microsoft.Network/networkSecurityGroups/deplo
     securityRules: spokeConfig.networkSecurityGroups.defaultNSG
     tags: allTags
     enableDefaultTelemetry: false
-    diagnosticLogsRetentionInDays: retentionDays
     diagnosticLogCategoriesToEnable: enabledLogsCategories
     diagnosticWorkspaceId: logAnalyticsWorkspace.id
   }
@@ -182,7 +176,6 @@ module SpokeVnet '../modules/Microsoft.Network/virtualNetworks/deploy.bicep' = {
     virtualNetworkPeerings: hubSpokePeering
     tags: allTags
     enableDefaultTelemetry: false
-    diagnosticLogsRetentionInDays: retentionDays
     diagnosticLogCategoriesToEnable: enabledLogsCategories
     diagnosticMetricsToEnable: enabledMetricsCategories
     diagnosticWorkspaceId: logAnalyticsWorkspace.id


### PR DESCRIPTION
Fixes cloud init lock related issues. The automated tests would regularly fail due to az CLI installation failure. The CLI failed due to DPKG lock being held by some other process when cloud init was running. Fixed by updated apt.conf in cloudinit to wait for lock.

retentionPolicyhave been deprecated on diagnostic settings. This was causing deployment failures. Removed those.